### PR TITLE
Add simple Flask dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-# Test
-# Test
-# Test
-# Test
-# Test
-# Test
+# Dashboard App
+
+This repository contains a simple Flask-based dashboard. The dashboard displays a few sample metrics.
+
+## Requirements
+- Python 3
+- Flask
+
+## Running the app
+
+1. Install dependencies:
+   ```bash
+   pip install Flask
+   ```
+2. Start the application:
+   ```bash
+   python dashboard.py
+   ```
+3. Open your browser at `http://localhost:5000` to view the dashboard.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,15 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    metrics = {
+        'users': 150,
+        'active_sessions': 45,
+        'revenue': 1234.56
+    }
+    return render_template('dashboard.html', metrics=metrics)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        .metric { margin: 10px 0; }
+    </style>
+</head>
+<body>
+    <h1>Dashboard</h1>
+    <div class="metric">Total Users: {{ metrics.users }}</div>
+    <div class="metric">Active Sessions: {{ metrics.active_sessions }}</div>
+    <div class="metric">Revenue: ${{ metrics.revenue }}</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal Flask app
- add a dashboard template showing sample metrics
- document how to run the dashboard

## Testing
- `pip install Flask`
- `python dashboard.py` (started web server)

------
https://chatgpt.com/codex/tasks/task_e_6885095c107c8333a027e5cfaeef3bd1